### PR TITLE
Implemented different way of persisting data for linkage cache using `pstore`.

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -20,15 +20,13 @@ module Homebrew
   module_function
 
   def linkage
-    check = LinkageDatabase.empty?(keys: ARGV.kegs.map(&:name))
-
     ARGV.kegs.each do |keg|
       ohai "Checking #{keg.name} linkage" if ARGV.kegs.size > 1
       result = LinkageChecker.new(keg)
 
       # Force a flush of the 'cache' and check dylibs if the `--rebuild`
       # flag is passed
-      result.check_dylibs if check || ARGV.include?("--rebuild")
+      result.check_dylibs if ARGV.include?("--rebuild")
 
       if ARGV.include?("--test")
         result.display_test_output

--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -9,53 +9,39 @@ class LinkageChecker
   def initialize(keg, formula = nil)
     @keg     = keg
     @formula = formula || resolve_formula(keg)
-    @store   = LinkageStore.new
+    @store   = LinkageStore.new(keg.name)
   end
 
-  # 'Hash type' cache values
+  # 'Hash-type' cache values
 
   def brewed_dylibs
-    @brewed_dylibs ||= store.fetch_hash_values!(
-      type: "brewed_dylibs", keys: [keg.name],
-    )
+    @brewed_dylibs ||= store.fetch_hash_values!(type: "brewed_dylibs")
   end
 
   def reverse_links
-    @reverse_links ||= store.fetch_hash_values!(
-      type: "reverse_links", keys: [keg.name],
-    )
+    @reverse_links ||= store.fetch_hash_values!(type: "reverse_links")
   end
 
   # 'Path-type' cached values
 
   def system_dylibs
-    @system_dylibs ||= store.fetch_path_values!(
-      type: "system_dylibs", keys: [keg.name],
-    )
+    @system_dylibs ||= store.fetch_path_values!(type: "system_dylibs")
   end
 
   def broken_dylibs
-    @broken_dylibs ||= store.fetch_path_values!(
-      type: "broken_dylibs", keys: [keg.name],
-    )
+    @broken_dylibs ||= store.fetch_path_values!(type: "broken_dylibs")
   end
 
   def variable_dylibs
-    @variable_dylibs ||= store.fetch_path_values!(
-      type: "variable_dylibs", keys: [keg.name],
-    )
+    @variable_dylibs ||= store.fetch_path_values!(type: "variable_dylibs")
   end
 
   def undeclared_deps
-    @undeclareddeps ||= store.fetch_path_values!(
-      type: "undeclared_deps", keys: [keg.name],
-    )
+    @undeclareddeps ||= store.fetch_path_values!(type: "undeclared_deps")
   end
 
   def unnecessary_deps
-    @unnecessary_deps ||= store.fetch_path_values!(
-      type: "unnecessary_deps", keys: [keg.name],
-    )
+    @unnecessary_deps ||= store.fetch_path_values!(type: "unnecessary_deps")
   end
 
   def check_dylibs
@@ -207,6 +193,7 @@ class LinkageChecker
   #
   # @return [nil]
   def reset_dylibs!
+    store.flush_cache!
     @system_dylibs    = Set.new
     @broken_dylibs    = Set.new
     @variable_dylibs  = Set.new
@@ -214,23 +201,21 @@ class LinkageChecker
     @reverse_links    = Hash.new { |h, k| h[k] = Set.new }
     @undeclared_deps  = []
     @unnecessary_deps = []
-    store.flush_cache_for_keys!(keys: [keg.name])
   end
 
-  # Updates store with library values
+  # Updates data store with package path values
   #
   # @return [nil]
   def store_dylibs!
     store.update!(
-      key: keg.name,
-      array_linkage_values: {
+      path_values: {
         system_dylibs: @system_dylibs,
         variable_dylibs: @variable_dylibs,
         broken_dylibs: @broken_dylibs,
         undeclared_deps: @undeclared_deps,
         unnecessary_deps: @unnecessary_deps,
       },
-      hash_linkage_values: {
+      hash_values: {
         brewed_dylibs: @brewed_dylibs,
         reverse_links: @reverse_links,
       },

--- a/Library/Homebrew/os/mac/linkage_database.rb
+++ b/Library/Homebrew/os/mac/linkage_database.rb
@@ -1,108 +1,13 @@
+require "pstore"
+
 #
-# LinkageDatabase is a module to interface with the sqlite3 database
-#
-# Database schema:
-#
-# CREATE TABLE IF NOT EXISTS linkage (
-#   id INTEGER PRIMARY KEY AUTOINCREMENT,
-#   name TEXT NOT NULL,
-#   path TEXT NOT NULL,
-#   type TEXT NOT NULL CHECK (type IN (#{types})),
-#   label TEXT CHECK (label IS NULL OR (type IN (#{hash_types}))),
-#   UNIQUE(name, path, type, label) ON CONFLICT IGNORE
-# );
+# LinkageDatabase is a module to interface with the pstore module
 #
 module LinkageDatabase
-  module_function
-
-  # Install and require SQLite3 ruby gem for caching purposes
-  Homebrew.install_gem_setup_path! "sqlite3"
-  require "sqlite3"
-
-  # GENERALIZED_LINKAGE_TYPES are rows which have a 'label' attribute which is
-  # NULL. There is a constraint check to ensure these types do not have a label:
-  #
-  #   - CHECK (label IS NULL OR (type IN (#{hash_types})))
-  GENERALIZED_TYPES = %w[
-    system_dylibs variable_dylibs broken_dylibs undeclared_deps unnecessary_deps
-  ].freeze
-
-  # HASH_LINKAGE_TYPES are rows which have a 'label' attribute which is NOT
-  # NULL. There is a constraint check to ensure these types have a label:
-  #
-  #   - CHECK (label IS NULL OR (type IN (#{hash_types})))
-  HASH_LINKAGE_TYPES = %w[
-    brewed_dylibs reverse_links
-  ].freeze
-
-  #
-  # LinkageDatabase::DatabaseInitializer initializes the database by creating
-  # the linkage table if it does not exist
-  #
-  class DatabaseInitializer
-    # Creates database table for SQLite3 linkage caching mechanism, if the
-    # table 'linkage' does not exist
-    #
-    # @return [nil]
-    def create_linkage_table
-      LinkageDatabase.db.execute <<~SQL
-        CREATE TABLE IF NOT EXISTS linkage (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          name TEXT NOT NULL,
-          path TEXT NOT NULL,
-          type TEXT NOT NULL CHECK (type IN (#{all_types})),
-          label TEXT CHECK (label IS NULL OR (type IN (#{hash_types}))),
-          UNIQUE(name, path, type, label) ON CONFLICT IGNORE
-        );
-      SQL
-    end
-
-    private
-
-    def all_types
-      LinkageDatabase.format_database_list(GENERALIZED_TYPES + HASH_LINKAGE_TYPES)
-    end
-
-    def hash_types
-      LinkageDatabase.format_database_list(HASH_LINKAGE_TYPES)
-    end
-  end
-
   # Expose linkage database through LinkageDatabase module
   #
-  # @return [SQLite3::Database] db
+  # @return [PStore] db
   def db
-    @db ||= SQLite3::Database.new "#{HOMEBREW_CACHE}/linkage.db"
-  end
-
-  # Checks if the database has been initialized
-  #
-  # @return [Boolean]
-  def empty?(keys:)
-    db.execute(
-      <<~SQL
-        SELECT COUNT(*) FROM linkage
-          WHERE name IN(#{format_database_list(keys)});
-      SQL
-    ) .flatten[0]
-      .zero?
-  end
-
-  # Takes in an array of strings, and formats them into a SQL list string
-  #
-  # @param  [Array[String]] list
-  # @return [String]
-  def format_database_list(list)
-    list
-      .map { |value| "'#{value}'" }
-      .join(", ")
-  end
-
-  begin
-    DatabaseInitializer.new.create_linkage_table
-  rescue SQLite3::CantOpenException => e
-    puts "Problem opening database file. Error: #{e}"
-  rescue SQLite3::SQLException => e
-    puts "Problem creating database tables for linkage database. Error: #{e}"
+    @db ||= PStore.new "#{HOMEBREW_CACHE}/linkage.pstore"
   end
 end

--- a/Library/Homebrew/os/mac/linkage_store.rb
+++ b/Library/Homebrew/os/mac/linkage_store.rb
@@ -1,5 +1,6 @@
 #
-# LinkageStore is a class which acts as an interface to SQLite3
+# LinkageStore is a class which acts as an interface to a persistent storage
+# mechanism
 #
 # If the cache hasn't changed, don't do extra processing in LinkageChecker.
 # Instead, just fetch the data stored in the cache
@@ -8,111 +9,75 @@
 require "os/mac/linkage_database"
 
 class LinkageStore
-  # Updates cached values in SQLite3 tables according to the type of data stored
+  include LinkageDatabase
+
+  attr_reader :key
+
+  # Initializes new LinkageStore class
   #
-  # @param  [String] key
-  # @param  [Hash] array_linkage_values
-  # @param  [Hash] hash_linkage_values
+  # @param  [String] keg_name
   # @return [nil]
-  def update!(key:,
-    array_linkage_values: {
+  def initialize(keg_name)
+    @key = keg_name
+  end
+
+  # Updates cached values in pstore according to the type of data stored
+  #
+  # @param  [Hash] path_values
+  # @param  [Hash] hash_values
+  # @return [nil]
+  def update!(
+    path_values: {
       system_dylibs: %w[], variable_dylibs: %w[], broken_dylibs: %w[],
       undeclared_deps: %w[], unnecessary_deps: %w[]
     },
-    hash_linkage_values: {
+    hash_values: {
       brewed_dylibs: {}, reverse_links: {}
-    })
-    array_linkage_values.each do |type, table_values|
-      insert_path_values(type, key, table_values)
-    end
-
-    hash_linkage_values.each do |type, values|
-      values.each do |label, list|
-        insert_hash_values(type, key, list, label)
-      end
+    }
+  )
+    db.transaction do
+      db[key] = {
+        path_values: path_values,
+        brewed_dylibs: format_hash_values(hash_values[:brewed_dylibs]),
+        reverse_links: format_hash_values(hash_values[:reverse_links]),
+      }
     end
   end
 
   # Fetches a subset of paths by looking up an array of keys
   #
   # @param  [String] type
-  # @param  [Array[String]] keys
   # @return [Array[String]]
-  def fetch_path_values!(type:, keys:)
-    LinkageDatabase.db.execute(
-      <<~SQL
-        SELECT path FROM linkage
-          WHERE type = '#{type}'
-          AND name IN(#{LinkageDatabase.format_database_list(keys)});
-      SQL
-    ).flatten
+  def fetch_path_values!(type:)
+    db.transaction { db[key][:path_values][type.to_sym] }
   end
 
   # Fetches path and label values from a table name given an array of keys and
   # returns them in a hash format with the labels as keys to an array of paths
   #
   # @param  [String] type
-  # @param  [Array[String]] keys
   # @return [Hash]
-  def fetch_hash_values!(type:, keys:)
-    hash = {}
-    LinkageDatabase.db.execute(
-      <<~SQL
-        SELECT label, path FROM linkage
-          WHERE type = '#{type}'
-          AND name IN(#{LinkageDatabase.format_database_list(keys)});
-      SQL
-    ).each { |row| (hash[row[0]] ||=[]) << row[1] }
-    hash
+  def fetch_hash_values!(type:)
+    db.transaction { db[key][type.to_sym] }
   end
 
-  # Deletes rows given an array of keys. If the row's name
-  # attribute contains a value in the array of keys, then that row is deleted
+  # Flushes the cache for the given 'key' name
   #
-  # @param  [Array[String]] keys
   # @return [nil]
-  def flush_cache_for_keys!(keys:)
-    LinkageDatabase.db.execute(
-      <<~SQL
-        DELETE FROM linkage
-          WHERE name IN(#{LinkageDatabase.format_database_list(keys)});
-      SQL
-    )
+  def flush_cache!
+    db.transaction { db.delete(key) }
   end
 
   private
 
-  def insert_path_values(type, key, values)
-    return if values.empty?
-
-    LinkageDatabase.db.execute(
-      <<~SQL
-        INSERT INTO linkage (name, path, type)
-          VALUES #{format_array_database_values(key, values, type)};
-      SQL
-    )
-  end
-
-  def insert_hash_values(type, key, values, label)
-    return if values.empty?
-
-    LinkageDatabase.db.execute(
-      <<~SQL
-        INSERT INTO linkage (name, path, type, label)
-          VALUES #{format_hash_database_values(key, values, type, label)};
-      SQL
-    )
-  end
-
-  def format_array_database_values(key, values, type)
-    values
-      .map { |value| "('#{key}', '#{value}', '#{type}')" }
-      .join(", ")
-  end
-
-  def format_hash_database_values(key, values, type, label)
-    values
-      .map { |value| "('#{key}', '#{value}', '#{type}', '#{label}')" }
-      .join(", ")
+  # `pstore` throws an error if the hash is empty, or if the hash contains Set
+  # values
+  #
+  # Error: can't dump hash with default proc
+  #
+  # @param  [Hash] hash
+  # @return [Hash]
+  def format_hash_values(hash)
+    hash.empty? ? nil : hash.map { |k, v| { k => v.to_a } }
   end
 end

--- a/Library/Homebrew/os/mac/linkage_store.rb
+++ b/Library/Homebrew/os/mac/linkage_store.rb
@@ -58,7 +58,8 @@ class LinkageStore
   # @param  [String] type
   # @return [Hash]
   def fetch_hash_values!(type:)
-    db.transaction { db[key][type.to_sym] }
+    data db.transaction { db[key][type.to_sym] }
+    data == nil ? {} : data.reduce({}, :update)
   end
 
   # Flushes the cache for the given 'key' name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is an experimental branch to look at the performance of using `pstore` over `SQLite3` as a mechanism of caching `brew linkage` information. It was recommended in https://github.com/Homebrew/brew/pull/3720 I try a `pstore` implementation to compare the performance of the two caching mechanisms.

## Performance Comparison

The `pstore` implementation is slower than the original `brew linkage` command without any caching. Storing and fetching data into `pstore` seems to be an expensive operation.

I've attached a flame graph to showcase the time spent in the `LinkageStore::update!` and `LinkageStore::fetch_path_values!`/`LinkageStore::fetch_hash_values!` methods.

### Flame Graph

*With the caching the command (instrumented starting from linkage.rb) took 42.2 seconds to complete. One `fetch_path_values!` method call took 3.51 seconds.*

<img width="1440" alt="screen shot 2018-01-24 at 12 44 25 pm" src="https://user-images.githubusercontent.com/8942499/35347879-6ce77042-0104-11e8-9e3f-7e42de1972b2.png">

*Note: I could refactor the `LinkageStore` class so that the number of database transactions is reduced, improving performance. I wanted to keep the same public interface for `LinkageStore` when experimenting with the changes. However, since the time it takes to perform one read is greater than the total time for the `SQLite3` implementation, I didn't refactor and investigate.*

### Raw Output

**`pstore`** caching solution
```
time brew linkage docker-machine mysql
==> Checking docker-machine linkage
System libraries:
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/Security.framework/Versions/A/Security
  /usr/lib/libSystem.B.dylib
==> Checking mysql linkage
System libraries:
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libedit.3.dylib
  /usr/lib/libsasl2.2.dylib
Homebrew libraries:
  /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib (openssl)
  /usr/local/opt/openssl/lib/libssl.1.0.0.dylib (openssl)
brew linkage docker-machine mysql  39.28s user 3.37s system 98% cpu 43.144 total
```

**`SQLite3`** caching solution
```
time brew linkage docker-machine mysql
==> Checking docker-machine linkage
System libraries:
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/Security.framework/Versions/A/Security
  /usr/lib/libSystem.B.dylib
==> Checking mysql linkage
System libraries:
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libedit.3.dylib
  /usr/lib/libsasl2.2.dylib
Homebrew libraries:
  /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib (openssl)
  /usr/local/opt/openssl/lib/libssl.1.0.0.dylib (openssl)
brew linkage docker-machine mysql  0.34s user 0.17s system 92% cpu 0.549 total
```

## Recommendation

I would recommend we use `SQLite3` for the caching mechanism. I believe the tradeoff of installing another gem in homebrew is worth the performance benefits of using `SQLite3` for caching.

If the homebrew team decides to go with the `SQLite3` implementation, I'd like to clean up the PR a bit. While writing this experimental branch, I noticed some ways I could refactor my existing code to make it cleaner.